### PR TITLE
Corrected instructions for Makefile flash: by removing TARGET

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ firmware.bin: firmware.elf
 	$(DOCKER) $(CROSS)-objcopy -O binary $< $@
 
 flash: firmware.bin
-	st-flash --reset write $(TARGET).bin 0x8000000
+	st-flash --reset write $< 0x8000000
 ```
 
 That's it! Now, `make flash` terminal command creates a `firmware.bin` file,


### PR DESCRIPTION
Hi! Found a probable issue and possible solution:

Previously, when a learner built the makefile by following the README, "make flash" generated an error. The issue was a reference to TARGET that didn't seem defined anywhere. (Maybe that was just me and this is invalid!) By making the change proposed, the makefile instructions align with the Makefile in Step-0-... and Step-1-... folders. Now "make flash" works for me with my main.c from the Minimal Firmware sections instructions and the Step-0-... main.c

Cheers!
John