### PR TITLE
Fixed README blinky gpio_write input

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,9 +780,9 @@ Finally, we're ready to modify our main loop to implement LED blinking:
 
 ```c
   for (;;) {
-    gpio_write(pin, true);
+    gpio_write(led, true);
     spin(999999);
-    gpio_write(pin, false);
+    gpio_write(led, false);
     spin(999999);
   }
 ```


### PR DESCRIPTION
Hi! Found a probable issue and probable solution:

Previously, when a learner followed the blinky README instructions, "make flash" generated an error. The issue was that variable pin in main.c wasn't previously defined. (Maybe that was just me and this is invalid!) By making the change proposed, the main.c from README instructions aligns with Step-1-... main.c. Now my main.c builds and flashes without error. The board blinks appropriately too.

Hopefully this is net helpful!
John