### PR TITLE
Fix typo in reference to USART3 tx pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -974,7 +974,7 @@ certain pins. A mimimal UART setup uses two pins, RX (receive) and TX (transmit)
 In a Nucleo board datasheet section 6.9 we see that one of the
 controllers, USART3, is using pins PD8 (TX) and PD9 (RX) and is connected to
 the on-board ST-LINK debugger. That means that if we configure USART3 and
-output data via the PD9 pin, we can see it on our workstation via the ST-LINK
+output data via the PD8 pin, we can see it on our workstation via the ST-LINK
 USB connection.
 
 Thus, let us create a handy API for the UART, the way we did it for GPIO.

--- a/README_tr-TR.md
+++ b/README_tr-TR.md
@@ -946,7 +946,7 @@ UART kurulumunda, RX (alma) ve TX (iletim) olmak üzere iki pin kullanır.
 Bir Nucleo kartı datasheet'inde bölüm 6.9'da, denetleyicilerden biri olan
 USART3'ün PD8 (TX) ve PD9 (RX) pinlerini kullandığını ve yerleşik
 ST-LINK hata ayıklayıcısına bağlı olduğunu görüyoruz.Bu, USART3'ü
-yapılandırırsak ve verileri PD9 pini aracılığıyla aktarırsak ST-LINK
+yapılandırırsak ve verileri PD8 pini aracılığıyla aktarırsak ST-LINK
 USB bağlantısı aracılığıyla bilgisayarımızdan okuyabiliriz.
 
 Bu da bize UART için GPIO ile birlikte bir API oluşturmayı gerektirtiyor.


### PR DESCRIPTION
Fixes typo when referring to USART3 transmitter pin in English and Turkish READMEs (correct pin is referenced in Chinese README).